### PR TITLE
Fix path printing and finalize script newline

### DIFF
--- a/project_code.py
+++ b/project_code.py
@@ -133,7 +133,7 @@ def find_paths(g: List[List[int]], src: int, dst: int) -> None:
                 q.append(new_path)
 
 
-print(find_paths(adjacency_list, name_to_id['Cristiano Ronaldo'], name_to_id['L. Messi']))
+find_paths(adjacency_list, name_to_id['Cristiano Ronaldo'], name_to_id['L. Messi'])
 
 # Create a matrix to represent the connections between the players
 Connection_Graph = np.zeros((df.shape[0], df.shape[0]))


### PR DESCRIPTION
## Summary
- call `find_paths` without printing its `None` return value
- ensure `project_code.py` ends with a newline so shell prompts display properly

## Testing
- `python3 -m py_compile project_code.py`

------
https://chatgpt.com/codex/tasks/task_e_68490a726fac83329993e46310c1f936